### PR TITLE
Added show import from clipboard and other missing shortcuts

### DIFF
--- a/src/routes/docs/shortcuts/+page.md
+++ b/src/routes/docs/shortcuts/+page.md
@@ -38,6 +38,11 @@ _These commands can simplify and speed up common tasks in FreeShow._
 | Undo                   | <Key>CTRL/CMD + Z</Key>     |
 | Shortcuts              | <Key>CTRL/CMD + ?</Key>     |
 |                        |                             |
+| Toggle Focus Mode      | <Key>CTRL/CMD + SHIFT + F</Key>|
+| Change Slide View      | <Key>CTRL/CMD + SHIFT + V</Key>|
+|                        |                             |
+| Show Import from Clipboard | <Key>CTRL/CMD + ALT + I</Key>|
+|                        |                             |
 | Remove Selection       | <Key>ESC</Key>              |
 | Clear All              | <Key>ESC</Key>              |
 | Clear Background       | <Key>F1</Key>               |

--- a/src/routes/docs/shortcuts/+page.md
+++ b/src/routes/docs/shortcuts/+page.md
@@ -11,51 +11,51 @@ description: A list of shortcuts available in FreeShow.
 
 _These commands can simplify and speed up common tasks in FreeShow._
 
-| Command                | Shortcut                    |
-| ---------------------- | --------------------------- |
-| Select All             | <Key>CTRL/CMD + A</Key>     |
-| Bold                   | <Key>CTRL/CMD + B</Key>     |
-| Copy                   | <Key>CTRL/CMD + C</Key>     |
-| Duplicate              | <Key>CTRL/CMD + D</Key>     |
-| Toggle Drawer          | <Key>CTRL/CMD + D</Key>     |
-| Export                 | <Key>CTRL/CMD + E</Key>     |
-| Search                 | <Key>CTRL/CMD + F</Key>     |
-| Quick Search           | <Key>CTRL/CMD + G</Key>     |
-| History                | <Key>CTRL/CMD + H</Key>     |
-| Italic                 | <Key>CTRL/CMD + I</Key>     |
-| Import                 | <Key>CTRL/CMD + I</Key>     |
-| Lock Output            | <Key>CTRL/CMD + L</Key>     |
-| Mute                   | <Key>CTRL/CMD + M</Key>     |
-| New Show               | <Key>CTRL/CMD + N</Key>     |
-| Toggle Output Screen   | <Key>CTRL/CMD + O</Key>     |
-| Update Output          | <Key>CTRL/CMD + R</Key>     |
-| Save                   | <Key>CTRL/CMD + S</Key>     |
-| Toggle Panels          | <Key>CTRL/CMD + T</Key>     |
-| Underline              | <Key>CTRL/CMD + U</Key>     |
-| Paste                  | <Key>CTRL/CMD + V</Key>     |
-| Cut                    | <Key>CTRL/CMD + X</Key>     |
-| Redo                   | <Key>CTRL/CMD + Y</Key>     |
-| Undo                   | <Key>CTRL/CMD + Z</Key>     |
-| Shortcuts              | <Key>CTRL/CMD + ?</Key>     |
-|                        |                             |
-| Toggle Focus Mode      | <Key>CTRL/CMD + SHIFT + F</Key>|
-| Change Slide View      | <Key>CTRL/CMD + SHIFT + V</Key>|
-|                        |                             |
-| Show Import from Clipboard | <Key>CTRL/CMD + ALT + I</Key>|
-|                        |                             |
-| Remove Selection       | <Key>ESC</Key>              |
-| Clear All              | <Key>ESC</Key>              |
-| Clear Background       | <Key>F1</Key>               |
-| Rename                 | <Key>F2</Key>               |
-| Clear Slide            | <Key>F2</Key>               |
-| Clear Overlays         | <Key>F3</Key>               |
-| Clear Audio            | <Key>F4</Key>               |
-| Quick Search           | <Key>F8</Key>               |
-| Toggle Fullscreen      | <Key>F11</Key>              |
-|                        |                             |
-| Change Tab             | <Key>NUM</Key>              |
-| Change Drawer Tab      | <Key>CTRL/CMD + NUM</Key>   |
-| Change Slide           | <Key>← / →</Key>            |
-| Change Project Item    | <Key>↑ / ↓</Key>            |
-| Change Drawer Item     | <Key>CTRL/CMD + ← / →</Key> |
-| Change Drawer Category | <Key>CTRL/CMD + ↑ / ↓</Key> |
+| Command                    | Shortcut                        |
+| -------------------------- | ------------------------------- |
+| Select All                 | <Key>CTRL/CMD + A</Key>         |
+| Bold                       | <Key>CTRL/CMD + B</Key>         |
+| Copy                       | <Key>CTRL/CMD + C</Key>         |
+| Duplicate                  | <Key>CTRL/CMD + D</Key>         |
+| Toggle Drawer              | <Key>CTRL/CMD + D</Key>         |
+| Export                     | <Key>CTRL/CMD + E</Key>         |
+| Search                     | <Key>CTRL/CMD + F</Key>         |
+| Quick Search               | <Key>CTRL/CMD + G</Key>         |
+| History                    | <Key>CTRL/CMD + H</Key>         |
+| Italic                     | <Key>CTRL/CMD + I</Key>         |
+| Import                     | <Key>CTRL/CMD + I</Key>         |
+| Lock Output                | <Key>CTRL/CMD + L</Key>         |
+| Mute                       | <Key>CTRL/CMD + M</Key>         |
+| New Show                   | <Key>CTRL/CMD + N</Key>         |
+| Toggle Output Screen       | <Key>CTRL/CMD + O</Key>         |
+| Update Output              | <Key>CTRL/CMD + R</Key>         |
+| Save                       | <Key>CTRL/CMD + S</Key>         |
+| Toggle Panels              | <Key>CTRL/CMD + T</Key>         |
+| Underline                  | <Key>CTRL/CMD + U</Key>         |
+| Paste                      | <Key>CTRL/CMD + V</Key>         |
+| Cut                        | <Key>CTRL/CMD + X</Key>         |
+| Redo                       | <Key>CTRL/CMD + Y</Key>         |
+| Undo                       | <Key>CTRL/CMD + Z</Key>         |
+| Shortcuts                  | <Key>CTRL/CMD + ?</Key>         |
+|                            |                                 |
+| Toggle Focus Mode          | <Key>CTRL/CMD + SHIFT + F</Key> |
+| Change Slide View          | <Key>CTRL/CMD + SHIFT + V</Key> |
+|                            |                                 |
+| Show Import from Clipboard | <Key>CTRL/CMD + ALT + I</Key>   |
+|                            |                                 |
+| Remove Selection           | <Key>ESC</Key>                  |
+| Clear All                  | <Key>ESC</Key>                  |
+| Clear Background           | <Key>F1</Key>                   |
+| Rename                     | <Key>F2</Key>                   |
+| Clear Slide                | <Key>F2</Key>                   |
+| Clear Overlays             | <Key>F3</Key>                   |
+| Clear Audio                | <Key>F4</Key>                   |
+| Quick Search               | <Key>F8</Key>                   |
+| Toggle Fullscreen          | <Key>F11</Key>                  |
+|                            |                                 |
+| Change Tab                 | <Key>NUM</Key>                  |
+| Change Drawer Tab          | <Key>CTRL/CMD + NUM</Key>       |
+| Change Slide               | <Key>← / →</Key>                |
+| Change Project Item        | <Key>↑ / ↓</Key>                |
+| Change Drawer Item         | <Key>CTRL/CMD + ← / →</Key>     |
+| Change Drawer Category     | <Key>CTRL/CMD + ↑ / ↓</Key>     |


### PR DESCRIPTION
I added the CTRL+ALT+I  **Show Import from Clipboard** short cut along with the CTRL+SHIFT+F **Toggle Focus Mode** and CTRL+SHIFT+V **Change Slide View** shortcuts that were missing from the documentation.

**Show Import from Clipboard** is also missing when using CTRL+? to show the short cuts in FreeShow.

![FreeShow_missing_shortcut_ctrl_question_mark](https://github.com/user-attachments/assets/ae6a28eb-92a9-4a11-865b-5e64d7088890)

Any other shortcuts that are missing that should be added to the documentation?