### PR TITLE
Added Github Issue Templates for Documentation and Website issues.

### DIFF
--- a/.github/ISSUE_TEMPLATE/Documentation.md
+++ b/.github/ISSUE_TEMPLATE/Documentation.md
@@ -1,0 +1,23 @@
+---
+name: Documentation
+about: Help us improve the FreeShow documentation
+title: "[Docs] "
+labels: documentation
+assignees: ''
+
+---
+
+**Describe the documentation needed**
+<!-- A clear and concise description of the documentation. Is this a new section in the documentation or is a correction to current documentation needed? If the latter, then please provide a link to the section of the current documentation. -->
+
+**Can you help write this documentation?**
+
+**Screenshots (Optional)**
+<!-- If applicable, add screenshots to help explain the needed documentation. -->
+
+**Is this documentation something in a new version of FreeShow? Does it apply to only certain operating systems?(Optional)**
+ - OS: <!-- [Windows/MacOS/Linux] -->
+ - FreeShow Version: <!-- [e.g. 1.0.0] -->
+
+**Additional Information**
+<!-- Add any other information about the documentation here. -->

--- a/.github/ISSUE_TEMPLATE/Website.md
+++ b/.github/ISSUE_TEMPLATE/Website.md
@@ -1,0 +1,24 @@
+---
+name: Website Issue
+about: Help us improve the FreeShow website FreeShow.app
+title: "[Website] "
+labels: website
+assignees: ''
+
+---
+
+**Describe the website bug**
+<!-- A clear and concise description of what the website issue is. -->
+
+**Reproducing**
+<!-- Please give some steps we can follow to recreate this issue. -->
+
+**Screenshots (Optional)**
+<!-- If applicable, add screenshots to help explain the website issue. -->
+
+**Version (Optional)**
+ - OS: <!-- [Windows/MacOS/Linux] -->
+ - FreeShow Version: <!-- [e.g. 1.0.0] -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: FreeShow Bug Report
+    url: https://github.com/ChurchApps/FreeShow/issues/new?template=bug_report.md
+    about: Help us improve the stability of FreeShow
+  - name: FreeShow Feature Request
+    url: https://github.com/ChurchApps/FreeShow/issues/new?template=feature_request.md
+    about: Suggest a new feature/improvement for FreeShow


### PR DESCRIPTION
 I also added a config.yml to configure contact links to the issue templates for the ChurchApps/FreeShow project.

If you like what I have done here I can put in a pull request for ChurchApps/FreeShow to do similar things. 

Like add contact links to allow one to quickly add issues for documentation and website issues. Add comment tags around instructions in the templates for issue filers so this content will appear less in the issue queue.

I have pushed this to the main branch on [frederickjh/FreeShowWeb](https://github.com/frederickjh/FreeShowWeb) so you can see the changes. Changes only show on Github if the changes are push to the default branch. Just go to the [Issue page](https://github.com/frederickjh/FreeShowWeb/issues) and click on the **New Issue** button to test.