### PR TITLE
Added Option key to the "Show Import from Clipboard".

### DIFF
--- a/src/routes/docs/shortcuts/+page.md
+++ b/src/routes/docs/shortcuts/+page.md
@@ -11,51 +11,51 @@ description: A list of shortcuts available in FreeShow.
 
 _These commands can simplify and speed up common tasks in FreeShow._
 
-| Command                    | Shortcut                        |
-| -------------------------- | ------------------------------- |
-| Select All                 | <Key>CTRL/CMD + A</Key>         |
-| Bold                       | <Key>CTRL/CMD + B</Key>         |
-| Copy                       | <Key>CTRL/CMD + C</Key>         |
-| Duplicate                  | <Key>CTRL/CMD + D</Key>         |
-| Toggle Drawer              | <Key>CTRL/CMD + D</Key>         |
-| Export                     | <Key>CTRL/CMD + E</Key>         |
-| Search                     | <Key>CTRL/CMD + F</Key>         |
-| Quick Search               | <Key>CTRL/CMD + G</Key>         |
-| History                    | <Key>CTRL/CMD + H</Key>         |
-| Italic                     | <Key>CTRL/CMD + I</Key>         |
-| Import                     | <Key>CTRL/CMD + I</Key>         |
-| Lock Output                | <Key>CTRL/CMD + L</Key>         |
-| Mute                       | <Key>CTRL/CMD + M</Key>         |
-| New Show                   | <Key>CTRL/CMD + N</Key>         |
-| Toggle Output Screen       | <Key>CTRL/CMD + O</Key>         |
-| Update Output              | <Key>CTRL/CMD + R</Key>         |
-| Save                       | <Key>CTRL/CMD + S</Key>         |
-| Toggle Panels              | <Key>CTRL/CMD + T</Key>         |
-| Underline                  | <Key>CTRL/CMD + U</Key>         |
-| Paste                      | <Key>CTRL/CMD + V</Key>         |
-| Cut                        | <Key>CTRL/CMD + X</Key>         |
-| Redo                       | <Key>CTRL/CMD + Y</Key>         |
-| Undo                       | <Key>CTRL/CMD + Z</Key>         |
-| Shortcuts                  | <Key>CTRL/CMD + ?</Key>         |
-|                            |                                 |
-| Toggle Focus Mode          | <Key>CTRL/CMD + SHIFT + F</Key> |
-| Change Slide View          | <Key>CTRL/CMD + SHIFT + V</Key> |
-|                            |                                 |
-| Show Import from Clipboard | <Key>CTRL/CMD + ALT + I</Key>   |
-|                            |                                 |
-| Remove Selection           | <Key>ESC</Key>                  |
-| Clear All                  | <Key>ESC</Key>                  |
-| Clear Background           | <Key>F1</Key>                   |
-| Rename                     | <Key>F2</Key>                   |
-| Clear Slide                | <Key>F2</Key>                   |
-| Clear Overlays             | <Key>F3</Key>                   |
-| Clear Audio                | <Key>F4</Key>                   |
-| Quick Search               | <Key>F8</Key>                   |
-| Toggle Fullscreen          | <Key>F11</Key>                  |
-|                            |                                 |
-| Change Tab                 | <Key>NUM</Key>                  |
-| Change Drawer Tab          | <Key>CTRL/CMD + NUM</Key>       |
-| Change Slide               | <Key>← / →</Key>                |
-| Change Project Item        | <Key>↑ / ↓</Key>                |
-| Change Drawer Item         | <Key>CTRL/CMD + ← / →</Key>     |
-| Change Drawer Category     | <Key>CTRL/CMD + ↑ / ↓</Key>     |
+| Command                    | Shortcut                             |
+| -------------------------- |--------------------------------------|
+| Select All                 | <Key>CTRL/CMD + A</Key>              |
+| Bold                       | <Key>CTRL/CMD + B</Key>              |
+| Copy                       | <Key>CTRL/CMD + C</Key>              |
+| Duplicate                  | <Key>CTRL/CMD + D</Key>              |
+| Toggle Drawer              | <Key>CTRL/CMD + D</Key>              |
+| Export                     | <Key>CTRL/CMD + E</Key>              |
+| Search                     | <Key>CTRL/CMD + F</Key>              |
+| Quick Search               | <Key>CTRL/CMD + G</Key>              |
+| History                    | <Key>CTRL/CMD + H</Key>              |
+| Italic                     | <Key>CTRL/CMD + I</Key>              |
+| Import                     | <Key>CTRL/CMD + I</Key>              |
+| Lock Output                | <Key>CTRL/CMD + L</Key>              |
+| Mute                       | <Key>CTRL/CMD + M</Key>              |
+| New Show                   | <Key>CTRL/CMD + N</Key>              |
+| Toggle Output Screen       | <Key>CTRL/CMD + O</Key>              |
+| Update Output              | <Key>CTRL/CMD + R</Key>              |
+| Save                       | <Key>CTRL/CMD + S</Key>              |
+| Toggle Panels              | <Key>CTRL/CMD + T</Key>              |
+| Underline                  | <Key>CTRL/CMD + U</Key>              |
+| Paste                      | <Key>CTRL/CMD + V</Key>              |
+| Cut                        | <Key>CTRL/CMD + X</Key>              |
+| Redo                       | <Key>CTRL/CMD + Y</Key>              |
+| Undo                       | <Key>CTRL/CMD + Z</Key>              |
+| Shortcuts                  | <Key>CTRL/CMD + ?</Key>              |
+|                            |                                      |
+| Toggle Focus Mode          | <Key>CTRL/CMD + SHIFT + F</Key>      |
+| Change Slide View          | <Key>CTRL/CMD + SHIFT + V</Key>      |
+|                            |                                      |
+| Show Import from Clipboard | <Key>CTRL/CMD + ALT/Option + I</Key> |
+|                            |                                      |
+| Remove Selection           | <Key>ESC</Key>                       |
+| Clear All                  | <Key>ESC</Key>                       |
+| Clear Background           | <Key>F1</Key>                        |
+| Rename                     | <Key>F2</Key>                        |
+| Clear Slide                | <Key>F2</Key>                        |
+| Clear Overlays             | <Key>F3</Key>                        |
+| Clear Audio                | <Key>F4</Key>                        |
+| Quick Search               | <Key>F8</Key>                        |
+| Toggle Fullscreen          | <Key>F11</Key>                       |
+|                            |                                      |
+| Change Tab                 | <Key>NUM</Key>                       |
+| Change Drawer Tab          | <Key>CTRL/CMD + NUM</Key>            |
+| Change Slide               | <Key>← / →</Key>                     |
+| Change Project Item        | <Key>↑ / ↓</Key>                     |
+| Change Drawer Item         | <Key>CTRL/CMD + ← / →</Key>          |
+| Change Drawer Category     | <Key>CTRL/CMD + ↑ / ↓</Key>          |


### PR DESCRIPTION
Mac keyboards have always had the Option key. Since the 1990s "Alt" has sometimes appeared on their keyboards as well. Newer keyboard since 2017 no longer include "Alt". Source Wikipedia - [Option_key](https://en.wikipedia.org/wiki/Option_key)

Our church has one of the new Mac keyboards that only has Option on the key.

It would be good too if this could also be changed in the shortcuts popup in FreeShow itself. It appears this is in src/frontend/components/main/popups/Shortcuts.svelte on line 45.
